### PR TITLE
Fix wooden slab compatibility

### DIFF
--- a/adaptions.lua
+++ b/adaptions.lua
@@ -46,6 +46,9 @@ cottages.craftitem_chest_locked = "default:chest_locked";
 cottages.craftitem_chest        = "default:chest";
 -- used for: hatch, table
 cottages.craftitem_slab_wood    = "stairs:slab_wood";
+if (minetest.get_modpath("slabcompat")) then
+    cottages.craftitem_slab_wood = "group:slab_wood"
+end
 
 -- texture used for fence gate and bed posts
 cottages.texture_furniture  = "default_wood.png";
@@ -100,11 +103,6 @@ if( not( minetest.registered_nodes["default:tree"])) then
 		-- does not look so well in this case as it's no bark; but what else shall we do?
 		cottages.textures_roof_wood = "cottages_minimal_wood.png";
 	end
-end
-
-if( minetest.get_modpath("moreblocks")
-  and minetest.registered_nodes[ "moreblocks:slab_wood" ]) then
-	cottages.craftitem_slab_wood = "moreblocks:slab_wood";
 end
 
 if( not( minetest.registered_nodes["wool:white"])) then

--- a/depends.txt
+++ b/depends.txt
@@ -6,3 +6,4 @@ intllib?
 trees?
 wool?
 moreblocks?
+slabcompat?


### PR DESCRIPTION
- When cottages detects `moreblocks` it defaults to using the `moreblocks` slabs, but these are only made on the sawmill. The line that references `moreblocks` can be commented out to allow the vanilla slab but break the `moreblocks` slab. Instead, it would be better to use a mod which detects all the wooden slabs properly.
- Ethereal and other modded woods are not compatible with cottages recipes, but can be made so with
slabcompat mod. This adds them to a group and lets cottages use all kinds of
modded wooden slabs.

Please see my repository [slapcompat](https://github.com/Montandalar/slabcompat/).