### PR TITLE
API for add fle threshing floor products

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -22,6 +22,7 @@
 
 cottages = {}
 
+
 -- there should be a way to distinguish this fork from others
 cottages.mod = "linuxforks"
 
@@ -77,12 +78,21 @@ end
 
 -- same for the threshing floor
 cottages.threshing_product = {};
+cottages.threshing_product[ "default:grass_1" ] = cottages.craftitem_seed_wheat;
 cottages.threshing_product[ "farming:wheat" ] = cottages.craftitem_seed_wheat;
 cottages.threshing_product[ "farming:barley" ] = cottages.craftitem_seed_barley;
 if farming.mod and (farming.mod == "redo" or farming.mod == "undo") then
 	cottages.threshing_product[ "farming:oat" ] = 'farming:seed_oat';
 	cottages.threshing_product[ "farming:rye" ] = 'farming:seed_rye';
 -- 	cottages.threshing_product[ "farming:rice" ] = 'farming:seed_rice';
+end
+
+function cottages:add_threshing_product(input, output)
+--Probably pretty obvious, but, for instance, 
+--	cottages:add_threshing_product("default:grass_1",{"farming:seed_wheat", "farming:seed_oat"})
+--	supports the two possible grains that can come from grass_1, 50/50 chance  of each
+--maybe should add some error checking sometime...
+	cottages.threshing_product[input] = output
 end
 
 

--- a/nodes_straw.lua
+++ b/nodes_straw.lua
@@ -310,7 +310,26 @@ minetest.register_node("cottages:threshing_floor", {
 			-- the player gets two kind of output, straw...
 			inv:add_item("straw", 'cottages:straw_mat '..tostring(output_straw));
 			-- add seeds depending on what was loaded in the threshing floor
-			inv:add_item("seeds", cottages.threshing_product[input_material]..' '..tostring(output_seeds));
+			local out=cottages.threshing_product[input_material]
+			if type(out)=="table" then
+				local o1={}
+				local k1, n1 
+				for n1=1,output_seeds do
+					k1=math.random(1,#out)
+					if type(o1[k1])=="number" then
+						o1[k1]=o1[k1]+1
+					else
+						o1[k1]=1
+					end
+				end
+				for n1=1,#out do
+					if type(o1[n1])=="number" then
+						inv:add_item("seeds", out[n1]..' '..tostring(o1[n1]));
+					end
+				end
+			else
+				inv:add_item("seeds", out..' '..tostring(output_seeds));
+			end
 			-- consume the wheat (or whatever is being processed)
 			inv:remove_item("harvest", input_material..' '..tostring(grain_to_process));
 


### PR DESCRIPTION
API makes it easy to enable other products, like the three grass types of farming redo. Grass_1 can become either wheat or oats; adding the line

cottages:add_threshing_product("default:grass_1",{"farming:seed_wheat", "farming:seed_oat"})

to any mod with optional depends of farming_redo and your fork of cottages is all it takes.

All existing such drops are 50/50, and cottages is deterministic ( all instocks become one straw and one seed) so this accomplishes that look and feel. Maybe a better solution would be an overall efficiency and various rarities of the outputs, nuch as gravelseive. 